### PR TITLE
fix of the Issue #10 : A dead link in the footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
 	<div class="footer">
 		<p class="text-muted">
 			Sat Live! has been created and hosted from 2000 to 2014 by the <a
-				href="http://www.innovation.it.uts.edu.au/lab/index.html">Innovation
+				href="http://www.uts.edu.au/research-and-teaching/our-research/quantum-computation-and-intelligent-systems/innovation-and">Innovation
 				and Enterprise Research Laboratory</a> at the University of Technology,
 			Sydney. It is now managed by <a href="http://www.cril.fr/">Daniel
 				Le Berre</a> from Artois University, France.


### PR DESCRIPTION
The link in the footer to indicate who are the Innovation and Entreprise Research Laboratory at the UTS was dead.
The link of the laboratory has been changed to the current link for this laboratory. (http://www.uts.edu.au/research-and-teaching/our-research/quantum-computation-and-intelligent-systems/innovation-and)