### PR TITLE
Add new tag : "modal-logic" and news about Advances in Modal Logic 2016

### DIFF
--- a/_posts/2015-07-13-Advances-in-Modal-Logic-2016.md
+++ b/_posts/2015-07-13-Advances-in-Modal-Logic-2016.md
@@ -1,0 +1,46 @@
+---
+layout: post
+title: "Advances in Modal Logic 2016"
+shorttitle: AIML'16 
+author: "Valentin Montmirail"
+tags: modal-logic CFP
+excerpt: "11th International Conference on Advances in Modal Logic, 2016, Budapest, Hungary."
+link: http://www.aiml.net/
+deadline: 2016-08-01
+---
+    ----------------------------------------------------------------------
+
+        11th International Conference on Advances in Modal Logic, 2016, 
+        Department of Logic, Institute of Philosophy, 
+        Eötvös University, Budapest Hungary.
+      
+                      --- AIML'2016 ---
+
+        Budapest, Hungary. 2016
+
+    -----------------------------------------------------------------------
+
+AiML 2016 will be organized by András Máté with Lev Beklemishev and Stéphane Demri as programme co-chairs. 
+
+The conference will be held at the Department of Logic, Institute of Philosophy, Eötvös University, Budapest.
+
+## IMPORTANT DATES
+
+* The deadline is just assumed from the previous conferences but the correct one will be announced...
+
+* Information will come ! 
+
+Follow [http://www.aiml.net/](http://www.aiml.net/) for updates.
+
+## SCOPE
+
+Advances in Modal Logic is a bi-annual international conference and book series in Modal Logic. 
+
+The aim of the conference series is to report on important new developments in pure and applied modal logic, and to do so at varying locations throughout the world. 
+
+The book series is based on the conferences. Please consult the background pages for further details.
+
+## CONTACT
+
+  * [Roman Kontchakov (roman@dcs.bbk.ac.uk)](mailto:roman@dcs.bbk.ac.uk)
+

--- a/modal-logic.html
+++ b/modal-logic.html
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+tag: modal-logic
+---
+


### PR DESCRIPTION
* Add of the tag "modal-logic" for all the news/Ph.D positions who are talking about Modal-Logic.

* Add a post of the Advances in Modal Logic 2016, who will be held in Budapest, Hungary in 2016.
  Only few information are present for now on the website, according to previous events, this conference will probably be in August. 

* I will keep an eye on this conference, and update this post as soon as the conference-holder give more informations. (maybe even contact them to know more :) ).