### PR TITLE
Add tusSAT solver

### DIFF
--- a/_solvers/tusSAT.md
+++ b/_solvers/tusSAT.md
@@ -1,0 +1,6 @@
+---
+name: tusSAT
+link: https://github.com/Sumith1896/tusSAT
+language: VHDL
+tags: FPGA
+---

--- a/solvers.html
+++ b/solvers.html
@@ -18,6 +18,8 @@ Those solvers are expected to run out-of-the-box on recent computers.
 
 {% include solverspanel.html title="Pre-processors" tags="PREPROC" %}
 
+{% include solverspanel.html title="FPGA based sat solvers" tags="FPGA" %}
+
 <h2>Pseudo-Boolean solvers</h2>
 
 {% include solverspanel.html title="Pseudo-Boolean Optimizers" tags="PB" %}


### PR DESCRIPTION
Adding the [tusSAT](https://github.com/Sumith1896/tusSAT) hardware based solver. It's still in a initial version and doesn't have CDCL but it can act as a direct solver for hardware or atleast a good starting for someone who wants to build one. Documentation and testbenches are included in the repository.

Could you please let me know if the site renders properly now?