### PR TITLE
CFP for LPAR 2018

### DIFF
--- a/_posts/2018-06-24-LPAR22.md
+++ b/_posts/2018-06-24-LPAR22.md
@@ -1,0 +1,166 @@
+---
+layout: post
+title: "LPAR'18 Call for papers"
+shorttitle: "Call for papers LPAR 2018"
+author: "Valentin Montmirail"
+tags: CFP Deadline
+excerpt: "22nd International Conference on Logic For Programming, Artificial Intelligence and Reasoning."
+link: http://www.LPAR-22.info
+deadline: 2018-08-13
+---
+
+                The 22nd International Conference on
+        Logic for Programming, Artificial Intelligence and Reasoning
+                            LPAR-22
+                Awassa, Ethiopia, 16-21 November 2018
+                      http://www.LPAR-22.info
+
+	                     -----------------------
+
+[https://easychair.org/conferences/?conf=lpar22](https://easychair.org/conferences/?conf=lpar22)
+
+The series of International Conferences on Logic for Programming, Artificial Intelligence and Reasoning (LPAR) is a forum where, year after year, some of the most renowned researchers in the areas of logic, automated reasoning, computational logic, programming languages and their applications come to present cutting-edge results, to discuss advances in these fields, and to exchange ideas in a scientifically emerging part of the world. The 22nd LPAR will be held will be held in Haile Resort, Awassa, Ethiopia, 16-21 November 2018. The proceedings will be published by EasyChair Publications, in the EPiC Series in Computing. The volume will be open access and the authors will retain copyright.
+
+# Important Dates:
+-------
+
+- Abstract submission 6th August 2018
+- Paper submission  13th August 2018
+- Notification  24th September 2018
+- Final version 15th October 2018
+- Early registration  15th October 2018
+- Workshops 16th November 2018
+- Conference  17-21st November 2018
+
+# Safety:
+-------
+
+We are aware of the US State Department's travel advisory. Please be assured that Awassa is not in any of the areas mentioned, and there is no need for any concern. Our local arrangments person emailed us "I can say with hundred percent of certainty Ethiopia is fully safe. Nothing to worry. I was talking to you before about the most remote areas where I took my tourists, which are totally safe now. Even there has been never a problem in Awassa.".
+
+# Topics:
+-------
+
+New results in the fields of computational logic and applications are welcome. Also welcome are more exploratory presentations, which may examine open questions and raise fundamental concerns about existing theories and practices. Topics of interest include, but are not limited to:
+
+- Abduction and interpolation methods
+- Answer set programming
+- Automated reasoning
+- Constraint programming
+- Contextual reasoning
+- Decision procedures
+- Description logics
+- Foundations of security
+- Hardware verification
+- Implementations of logic
+- Inconsistency- and exception tolerant reasoning
+- Interactive theorem proving
+- Knowledge representation and reasoning
+- Logic and computational complexity
+- Logic and databases
+- Logic and games
+- Logic and machine learning
+- Logic and the web
+- Logic and types
+- Logic in artificial intelligence
+- Logic of distributed systems
+- Logic of knowledge and belief
+- Logic programming
+- Logical aspects of concurrency
+- Logical foundations of programming
+- Modal and temporal logics
+- Model checking
+- Non-monotonic reasoning
+- Ontologies and large knowledge bases
+- Paraconsistent logics
+- Probabilistic and fuzzy reasoning
+- Program analysis
+- Rewriting
+- Satisfiability checking
+- Satisfiability modulo theories
+- Software verification
+- Specification using logic
+- Unification theory
+
+# Organization:
+-------------------
+
+### Program Chairs:
+
+- Gilles Barthe (IMDEA Software Institute)
+- Margus Veanes (Microsoft Research)
+- Martin Hofmann (Ludwig-Maximilians-Universität München, in memoriam)
+
+### Workshops and Tutorials Chair:
+
+- Temesghen Kahsai (Groq Security)
+
+### Conference Chair:
+
+- Geoff Sutcliffe (University of Miami, USA)
+
+# Submission details:
+-------------------
+
+Submissions of two kinds are welcome:
+
+* Regular papers that describe solid new research results. They can be up to 15 pages long in EasyChair style, including figures but excluding references and appendices (that reviewers are not required to read).
+ 
+* Experimental and tool papers that describe implementations of systems, report experiments with implemented systems, or compare implemented systems. They can be up to 8 pages long in the EasyChair style.
+
+Both types of papers must be electronically submitted in PDF via EasyChair:
+
+[https://easychair.org/conferences/?conf=lpar22](https://easychair.org/conferences/?conf=lpar22)
+
+Authors must register a title and an abstract by the abstract submission deadline.
+
+# Participation:
+-------------------
+
+Authors of accepted papers are required to ensure that at least one of them will be present at the conference.
+
+# Workshop and Tutorial Proposals:
+-------------------
+
+Proposals for workshops and tutorials to be held in conjunctionwith LPAR-22 are solicited. Please email proposals to the Workshops and Tutorials Chair.
+
+# Program Commitee:
+-------------------
+
+- June Andronick (CSIRO|Data61 and UNSW)
+- Franz Baader (TU Dresden)
+- Gilles Barthe (IMDEA Software Institute) - chair
+- Hubert Comon (LSV, CNRS & ENS de Cachan)
+- Thierry Coquand (Chalmers University of Technology)
+- Cas Cremers (University of Oxford)
+- Loris D'Antoni (University of Wisconsin-Madison)
+- Pedro R. D'Argenio (Universidad Nacional de Córdoba - CONICET)
+- Nachum Dershowitz (Tel Aviv University)
+- Thomas Eiter (Vienna University of Technology)
+- Michael Emmi (SRI International)
+- Marco Gaboardi (Computer Science and Engineering - University at Buffalo, SUNY)
+- Adria Gascon (The Alan Turing Institute / Warwick University)
+- Herman Geuvers (Radboud University)
+- Jürgen Giesl (RWTH Aachen University)
+- Orna Grumberg (Technion - Israel Institute of Technology)
+- John Harrison (Amazon Web Services)
+- Lukas Holik (Brno University of Technology)
+- Reiner Hähnle (TU Darmstadt)
+- Temesghen Kahsai (Groq)
+- Joost-Pieter Katoen (RWTH Aachen University)
+- Dexter Kozen (Cornell University)
+- Joe Leslie-Hurd (Intel)
+- Leonid Libkin (The University of Edinburgh)
+- Joao Marques-Silva (Universidade de Lisboa)
+- Annabelle McIver (Macquarie University)
+- Georg Moser (University of Innsbruck)
+- Peter Müller (ETH Zurich)
+- Nicola Olivetti (LSIS, Aix-Marseille University)
+- Frank Pfenning (Carnegie Mellon University)
+- David Pym (University College London)
+- David Sands (Chalmers University of Technology)
+- Davide Sangiorgi (University of Bologna)
+- Torsten Schaub (University of Potsdam)
+- Geoff Sutcliffe (University of Miami) - chair
+- Cesare Tinelli (The University of Iowa)
+- Ashish Tiwari (SRI International)
+- Margus Veanes (Microsoft) - chair


### PR DESCRIPTION
LPAR is a conference that can be of interest to the SAT community.
The submission deadline is in August, so we are in the good timing to push the CFP.